### PR TITLE
Create a view and a route to access invoices by type and sent status

### DIFF
--- a/src/main/java/org/taktik/icure/dao/InvoiceDAO.java
+++ b/src/main/java/org/taktik/icure/dao/InvoiceDAO.java
@@ -26,6 +26,8 @@ import org.ektorp.support.View;
 import org.taktik.icure.db.PaginatedList;
 import org.taktik.icure.db.PaginationOffset;
 import org.taktik.icure.entities.Invoice;
+import org.taktik.icure.entities.embed.InvoiceType;
+import org.taktik.icure.entities.embed.MediumType;
 
 public interface InvoiceDAO extends GenericDAO<Invoice> {
 	PaginatedList<Invoice> findByHcParty(String hcParty, Long fromDate, Long toDate, PaginationOffset<ComplexKey> paginationOffset);
@@ -37,6 +39,8 @@ public interface InvoiceDAO extends GenericDAO<Invoice> {
 	List<Invoice> listByHcPartyPatientFk(String hcParty, Set<String> secretPatientKeys);
 	List<Invoice> listByHcPartyRecipientIdsUnsent(String hcParty, Set<String> recipientIds);
 	List<Invoice> listByHcPartyPatientFkUnsent(String hcParty, Set<String> secretPatientKeys);
+
+	List<Invoice> listByHcPartySentMediumTypeInvoiceTypeSentDate(String hcParty, MediumType sentMediumType, InvoiceType invoiceType, boolean sent, Long fromDate, Long toDate);
 
 	List<Invoice> listByServiceIds(Set<String> serviceIds);
 

--- a/src/main/java/org/taktik/icure/dao/impl/InvoiceDAOImpl.java
+++ b/src/main/java/org/taktik/icure/dao/impl/InvoiceDAOImpl.java
@@ -38,6 +38,8 @@ import org.taktik.icure.db.PaginatedList;
 import org.taktik.icure.db.PaginationOffset;
 import org.taktik.icure.entities.Document;
 import org.taktik.icure.entities.Invoice;
+import org.taktik.icure.entities.embed.InvoiceType;
+import org.taktik.icure.entities.embed.MediumType;
 
 @Repository("invoiceDAO")
 @View(name = "all", map = "function(doc) { if (doc.java_type == 'org.taktik.icure.entities.Invoice' && !doc.deleted) emit( null, doc._id )}")
@@ -114,7 +116,21 @@ public class InvoiceDAOImpl extends GenericIcureDAOImpl<Invoice> implements Invo
 		return queryResults(createQuery("by_hcparty_patientfk_unsent").includeDocs(true).keys(Arrays.asList(keys)));
 	}
 
-	@Override
+    @Override
+	@View(name = "by_hcparty_sentmediumtype_invoicetype_sent_date", map = "classpath:js/invoice/By_hcparty_sentmediumtype_invoicetype_sent_date.js")
+    public List<Invoice> listByHcPartySentMediumTypeInvoiceTypeSentDate(String hcParty, MediumType sentMediumType, InvoiceType invoiceType, boolean sent, Long fromDate, Long toDate) {
+		ComplexKey startKey = ComplexKey.of(hcParty, sentMediumType, invoiceType, sent);
+		ComplexKey endKey = ComplexKey.of(hcParty, sentMediumType, invoiceType, sent, "{}");
+		if(fromDate != null){
+			startKey = ComplexKey.of(hcParty, sentMediumType, invoiceType, sent, fromDate);
+			if(toDate != null){
+				endKey = ComplexKey.of(hcParty, sentMediumType, invoiceType, sent, toDate);
+			}
+		}
+		return queryResults(createQuery("by_hcparty_sentmediumtype_invoicetype_sent_date").includeDocs(true).startKey(startKey).endKey(endKey));
+    }
+
+    @Override
 	@View(name = "by_serviceid", map = "classpath:js/invoice/By_serviceid_map.js")
 	public List<Invoice> listByServiceIds(Set<String> serviceIds) {
 		return queryResults(createQuery("by_serviceid").includeDocs(true).keys(serviceIds));

--- a/src/main/java/org/taktik/icure/logic/InvoiceLogic.java
+++ b/src/main/java/org/taktik/icure/logic/InvoiceLogic.java
@@ -46,6 +46,8 @@ public interface InvoiceLogic {
 	List<Invoice> listByHcPartyRecipientIds(String hcParty, Set<String> recipientIds);
 	List<Invoice> listByHcPartyPatientSks(String hcParty, Set<String> patientSks);
 
+	List<Invoice> listByHcPartySentMediumTypeInvoiceTypeSentDate(String hcParty, MediumType sentMediumType, InvoiceType invoiceType, boolean sent, Long fromDate, Long toDate);
+
 	List<Invoice> listByHcPartyRecipientIdsUnsent(String hcParty, Set<String> recipientIds);
 
 	List<Invoice> listByHcPartyPatientSksUnsent(String hcParty, Set<String> secretPatientKeys);

--- a/src/main/java/org/taktik/icure/logic/impl/InvoiceLogicImpl.java
+++ b/src/main/java/org/taktik/icure/logic/impl/InvoiceLogicImpl.java
@@ -129,6 +129,11 @@ public class InvoiceLogicImpl extends GenericLogicImpl<Invoice, InvoiceDAO> impl
 	}
 
 	@Override
+	public List<Invoice> listByHcPartySentMediumTypeInvoiceTypeSentDate(String hcParty, MediumType sentMediumType, InvoiceType invoiceType, boolean sent, Long fromDate, Long toDate) {
+		return invoiceDAO.listByHcPartySentMediumTypeInvoiceTypeSentDate(hcParty, sentMediumType, invoiceType, sent, fromDate, toDate);
+	}
+
+	@Override
 	public List<Invoice> listByHcPartyRecipientIdsUnsent(String hcParty, Set<String> recipientIds) {
 		return invoiceDAO.listByHcPartyRecipientIdsUnsent(hcParty, recipientIds);
 	}

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/facade/InvoiceFacade.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/facade/InvoiceFacade.java
@@ -344,6 +344,23 @@ public class InvoiceFacade implements OpenApiFacade{
 	}
 
 	@ApiOperation(
+			value = "List invoices by type, sent or unsent",
+			response = InvoiceDto.class,
+			responseContainer = "Array",
+			httpMethod = "GET",
+			notes = "Keys have to delimited by coma"
+	)
+	@GET
+	@Path("/byHcParty/{hcPartyId}/mediumType/{sentMediumType}/invoiceType/{invoiceType}/sent/{sent}")
+	public Response listByHcPartySentMediumTypeInvoiceTypeSentDate(@PathParam("hcPartyId") String hcParty, @PathParam("sentMediumType") MediumType sentMediumType,
+																   @PathParam("invoiceType") InvoiceType invoiceType, @PathParam("sent") boolean sent,
+																   @QueryParam("from") Long fromDate, @QueryParam("to") Long toDate) {
+		List<Invoice> invoices = invoiceLogic.listByHcPartySentMediumTypeInvoiceTypeSentDate(hcParty, sentMediumType, invoiceType, sent, fromDate, toDate);
+		List<InvoiceDto> invoicesDto = invoices.stream().map(el -> mapper.map(el, InvoiceDto.class)).collect(Collectors.toList());
+		return Response.ok().entity(invoicesDto).build();
+	}
+
+	@ApiOperation(
 			value = "Update delegations in healthElements.",
 			httpMethod = "POST",
 			notes = "Keys must be delimited by coma"

--- a/src/main/resources/org/taktik/icure/dao/impl/js/invoice/By_hcparty_sentmediumtype_invoicetype_sent_date.js
+++ b/src/main/resources/org/taktik/icure/dao/impl/js/invoice/By_hcparty_sentmediumtype_invoicetype_sent_date.js
@@ -1,0 +1,7 @@
+map = function (doc) {
+	if (doc.java_type == 'org.taktik.icure.entities.Invoice' && !doc.deleted && !!doc.sentMediumType && !!doc.invoiceType && doc.delegations && Object.keys(doc.delegations).length) {
+		Object.keys(doc.delegations).forEach(function (k) {
+            emit([k, doc.sentMediumType, doc.invoiceType, !!doc.sentDate, doc.invoiceDate], doc._id)
+		});
+	}
+};


### PR DESCRIPTION
This PR allows to query a view named "by_hcparty_sentmediumtype_invoicetype_sent_date", so you can query now for example "the unsent eFact invoices created this month".