### PR TITLE
Add a field subtype in entitytemplate

### DIFF
--- a/src/main/java/org/taktik/icure/entities/EntityTemplate.java
+++ b/src/main/java/org/taktik/icure/entities/EntityTemplate.java
@@ -36,6 +36,7 @@ public class EntityTemplate extends StoredDocument {
 	String descr;
 	@NotNull
 	String entityType;
+	String subType;
 	Boolean defaultTemplate;
 
 	List<Map<String,Object>> entity;
@@ -63,6 +64,10 @@ public class EntityTemplate extends StoredDocument {
 	public void setEntityType(String entityType) {
 		this.entityType = entityType;
 	}
+
+	public String getSubType() { return subType; }
+
+	public void setSubType(String subType) { this.subType = subType; }
 
 	public List<Map<String, Object>> getEntity() {
 		return entity;

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/dto/EntityTemplateDto.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/dto/EntityTemplateDto.java
@@ -28,6 +28,8 @@ public class EntityTemplateDto extends StoredDto implements Serializable {
 
 	String entityType;
 	Boolean defaultTemplate;
+
+	String subType;
 	List<Map<String,Object>> entity;
 
 	public String getUserId() {
@@ -53,6 +55,10 @@ public class EntityTemplateDto extends StoredDto implements Serializable {
 	public void setEntityType(String entityType) {
 		this.entityType = entityType;
 	}
+
+	public String getSubType() { return subType; }
+
+	public void setSubType(String subType) { this.subType = subType; }
 
 	public List<Map<String, Object>> getEntity() {
 		return entity;


### PR DESCRIPTION
As we will migrate the structure of magistrales, we need a subtype to store the information that this medication is a magistrale. This was decided with @aduchateau