### PR TITLE
[MS-226] Strengthen import encoding detection

### DIFF
--- a/src/main/java/org/taktik/icure/be/format/logic/impl/GenericResultFormatLogicImpl.java
+++ b/src/main/java/org/taktik/icure/be/format/logic/impl/GenericResultFormatLogicImpl.java
@@ -23,6 +23,10 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -86,14 +90,20 @@ public abstract class GenericResultFormatLogicImpl {
 
 	protected String decodeRawData(byte[] rawData) throws IOException {
 		String text;
-		String frenchCp850OrCp1252 = org.taktik.icure.db.StringUtils.detectFrenchCp850Cp1252(rawData);
-		if ("cp850".equals(frenchCp850OrCp1252)) {
-			text = new String(rawData, "cp850");
-		} else if ("cp1252".equals(frenchCp850OrCp1252)) {
-			text = new String(rawData, "cp1252");
-		} else {
-			text = new String(rawData, StandardCharsets.UTF_8);
+
+		CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder();
+		try {
+			CharBuffer decodedChars = utf8Decoder.decode(ByteBuffer.wrap(rawData));
+			text = decodedChars.toString();
+		} catch (CharacterCodingException e) {
+			String frenchCp850OrCp1252 = org.taktik.icure.db.StringUtils.detectFrenchCp850Cp1252(rawData);
+			if ("cp850".equals(frenchCp850OrCp1252)) {
+				text = new String(rawData, "cp850");
+			} else {
+				text = new String(rawData, "cp1252");
+			}
 		}
+
 		return text;
 	}
 

--- a/src/main/java/org/taktik/icure/db/StringUtils.java
+++ b/src/main/java/org/taktik/icure/db/StringUtils.java
@@ -101,7 +101,7 @@ public class StringUtils {
 					score--;
 				}
 			}
-			return score > 3 ? "cp850" : score < -3 ? "cp1252" : null;
+			return score > 0 ? "cp850" : "cp1252";
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/taktik/icure/db/StringUtils.java
+++ b/src/main/java/org/taktik/icure/db/StringUtils.java
@@ -80,24 +80,44 @@ public class StringUtils {
 			int c;
 			while ((c = br.read()) != -1) {
 				if (c == '\u00e8') {
+					// from cp850 (likely): LATIN SMALL LETTER E WITH GRAVE
+					// from cp1252 (unlikely): LATIN CAPITAL LETTER S WITH CARON
 					score++;
 				} else if (c == '\u00e9') {
+					// from cp850 (likely): LATIN SMALL LETTER E WITH ACUTE
+					// from cp1252 (unlikely): SINGLE LOW-9 QUOTATION MARK
 					score++;
 				} else if (c == '\u00e0') {
+					// from cp850 (likely): LATIN SMALL LETTER A WITH GRAVE
+					// from cp1252 (unlikely): HORIZONTAL ELLIPSIS
 					score++;
 				} else if (c == '\u00e7') {
+					// from cp850 (likely): LATIN SMALL LETTER C WITH CEDILLA
+					// from cp1252 (unlikely): DOUBLE DAGGER
 					score++;
 				} else if (c == '\u00b5') {
+					// from cp850 (likely): MICRO SIGN
+					// from cp1252 (unlikely): LATIN SMALL LETTER AE
 					score++;
 				} else if (c == '\u00d3') {
+					// from cp850 (unlikely): LATIN CAPITAL LETTER O WITH ACUTE
+					// from cp1252 (likely): LATIN SMALL LETTER A WITH GRAVE
 					score--;
 				} else if (c == '\u00fe') {
+					// from cp850 (unlikely): LATIN SMALL LETTER THORN
+					// from cp1252 (likely): LATIN SMALL LETTER C WITH CEDILLA
 					score--;
 				} else if (c == '\u00de') {
+					// from cp850 (unlikely): LATIN CAPITAL LETTER THORN
+					// from cp1252 (likely): LATIN SMALL LETTER E WITH GRAVE
 					score--;
 				} else if (c == '\u00da') {
+					// from cp850 (unlikely): LATIN CAPITAL LETTER U WITH ACUTE
+					// from cp1252 (likely): LATIN SMALL LETTER E WITH ACUTE
 					score--;
 				} else if (c == '\u00c1') {
+					// from cp850 (unlikely): LATIN CAPITAL LETTER A WITH ACUTE
+					// from cp1252 (likely): MICRO SIGN
 					score--;
 				}
 			}

--- a/src/main/java/org/taktik/icure/db/StringUtils.java
+++ b/src/main/java/org/taktik/icure/db/StringUtils.java
@@ -95,6 +95,10 @@ public class StringUtils {
 					// from cp850 (likely): LATIN SMALL LETTER C WITH CEDILLA
 					// from cp1252 (unlikely): DOUBLE DAGGER
 					score++;
+				} else if (c == '\u00b3') {
+					// from cp850 (likely): SUPERSCRIPT THREE
+					// from cp1252 (unlikely): LATIN SMALL LETTER U WITH DIAERESIS
+					score++;
 				} else if (c == '\u00b5') {
 					// from cp850 (likely): MICRO SIGN
 					// from cp1252 (unlikely): LATIN SMALL LETTER AE
@@ -119,6 +123,9 @@ public class StringUtils {
 					// from cp850 (unlikely): LATIN CAPITAL LETTER A WITH ACUTE
 					// from cp1252 (likely): MICRO SIGN
 					score--;
+				} else if (c == '\u2502') {
+					// from cp850 (unlikely): BOX DRAWINGS LIGHT VERTICAL
+					// from cp1252 (likely): SUPERSCRIPT THREE
 				}
 			}
 			return score > 0 ? "cp850" : "cp1252";


### PR DESCRIPTION
This PR strengthens the distinction between UTF-8, CP-850 and ISO-8859-1/CP-1252.

UTF-8 is tried first because that is very unlikely to succeed with input data encoded in CP-850, ISO-8859-1 or CP-1252.

Then, the same heuristic is used to distinguish between CP-850 and CP-1252. The heuristic was made more sensitive (it does not return null anymore) because there is no more need for UTF-8 fallback.

The character `³` (SUPERSCRIPT THREE) was added to the heuristic so that CP-850 with such characters are correctly handled.