### PR TITLE
Add end point for contact list by opening date

### DIFF
--- a/src/main/java/org/taktik/icure/dao/ContactDAO.java
+++ b/src/main/java/org/taktik/icure/dao/ContactDAO.java
@@ -52,7 +52,7 @@ public interface ContactDAO extends GenericDAO<Contact> {
 
     PaginatedList<Contact> listContacts(String hcPartyId, PaginationOffset<String> pagination);
 
-    PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long openingDate, PaginationOffset<List<Serializable>> pagination);
+    PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long startOpeningDate, Long endOpeningDate, PaginationOffset pagination);
 
     List<Contact> findByHcPartyFormId(String hcPartyId, String formId);
 

--- a/src/main/java/org/taktik/icure/dao/impl/ContactDAOImpl.java
+++ b/src/main/java/org/taktik/icure/dao/impl/ContactDAOImpl.java
@@ -74,16 +74,10 @@ public class ContactDAOImpl extends GenericIcureDAOImpl<Contact> implements Cont
 
     @Override
     @View(name = "by_hcparty_openingdate", map = "classpath:js/contact/By_hcparty_openingdate.js")
-    public PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long openingDate, PaginationOffset<List<Serializable>> pagination) {
-		ComplexKey startKey = pagination.getStartKey() == null ? ComplexKey.of(hcPartyId, openingDate) : ComplexKey.of(pagination.getStartKey().toArray());
-		ComplexKey endKey = ComplexKey.of(hcPartyId, openingDate);
-
-		return pagedQueryView(
-                "by_hcparty_openingdate",
-                startKey,
-                endKey,
-                pagination, false
-		);
+    public PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long startOpeningDate, Long endOpeningDate, PaginationOffset pagination) {
+      ComplexKey startKey =  ComplexKey.of(hcPartyId, startOpeningDate);
+      ComplexKey endKey = ComplexKey.of(hcPartyId, endOpeningDate);
+      return pagedQueryView("by_hcparty_openingdate", startKey, endKey, pagination, false);
     }
 
     @Override

--- a/src/main/java/org/taktik/icure/logic/ContactLogic.java
+++ b/src/main/java/org/taktik/icure/logic/ContactLogic.java
@@ -71,5 +71,8 @@ public interface ContactLogic extends EntityPersister<Contact, String> {
 
 	PaginatedList<Service> filterServices(PaginationOffset paginationOffset, FilterChain<Service> filter);
 
+	PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long startOpeningDate, Long endOpeningDate, PaginationOffset offset);
+
+
 	void solveConflicts();
 }

--- a/src/main/java/org/taktik/icure/logic/impl/ContactLogicImpl.java
+++ b/src/main/java/org/taktik/icure/logic/impl/ContactLogicImpl.java
@@ -335,4 +335,12 @@ public class ContactLogicImpl extends GenericLogicImpl<Contact, ContactDAO> impl
 		});
 	}
 
+
+	@Override
+	public PaginatedList<Contact> listContactsByOpeningDate(String hcPartyId, Long startOpeningDate, Long endOpeningDate, PaginationOffset offset) {
+		PaginatedList<Contact> contacts;
+		contacts = contactDAO.listContactsByOpeningDate(hcPartyId, startOpeningDate, endOpeningDate, offset);
+		return contacts;
+	}
+
 }

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/facade/ContactFacade.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/facade/ContactFacade.java
@@ -613,6 +613,51 @@ public class ContactFacade implements OpenApiFacade {
         return response;
     }
 
+    @ApiOperation(
+        value = "List contacts bu opening date parties with(out) pagination",
+        response = org.taktik.icure.services.external.rest.v1.dto.ContactPaginatedList.class,
+        httpMethod = "GET",
+        notes = "Returns a list of contacts."
+    )
+    @GET
+    @Path("/byOpeningDate")
+    public Response listContactsByOpeningDate(
+            @ApiParam(value = "The contact openingDate", required = true) @QueryParam("startKey") Long startKey,
+            @ApiParam(value = "The contact max openingDate", required = true) @QueryParam("endKey") Long endKey,
+            @ApiParam(value = "hcpartyid", required = true) @QueryParam("hcpartyid") String hcpartyid,
+            @ApiParam(value = "A contact party document ID", required = false) @QueryParam("startDocumentId") String startDocumentId,
+            @ApiParam(value = "Number of rows", required = false) @QueryParam("limit") Integer limit) {
+
+        Response response;
+
+        PaginationOffset<Object> paginationOffset = new PaginationOffset<>(startKey, startDocumentId, null, limit);
+
+        PaginatedList<Contact> contacts;
+        contacts = contactLogic.listContactsByOpeningDate(hcpartyid, startKey, endKey, paginationOffset);
+
+        if (contacts != null) {
+            if (contacts.getRows() == null) {
+                contacts.setRows(new ArrayList<>());
+            }
+
+            org.taktik.icure.services.external.rest.v1.dto.PaginatedList<ContactDto> paginatedContactDtoList =
+                    new org.taktik.icure.services.external.rest.v1.dto.PaginatedList<>();
+            mapper.map(
+                    contacts,
+                    paginatedContactDtoList,
+                    new TypeBuilder<PaginatedList<Contact>>() {
+                    }.build(),
+                    new TypeBuilder<org.taktik.icure.services.external.rest.v1.dto.PaginatedList<ContactDto>>() {
+                    }.build()
+            );
+            response = ResponseUtils.ok(paginatedContactDtoList);
+        } else {
+            response = ResponseUtils.internalServerError("Listing contacts failed.");
+        }
+
+        return response;
+    }
+
     @Context
     public void setMapper(MapperFacade mapper) {
         this.mapper = mapper;


### PR DESCRIPTION
This add an end point to query contacts by their `openingDate` based on the existing view `by_hcparty_openingdate`
