### PR TITLE
[MS-379] Boolean TypedValue mapping fix

### DIFF
--- a/src/main/java/org/taktik/icure/services/external/rest/v1/dto/TypedValueDto.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/dto/TypedValueDto.java
@@ -147,12 +147,12 @@ public class TypedValueDto implements Serializable, Comparable<TypedValueDto> {
 		this.type = type;
 	}
 
-	public Integer getBooleanValue() {
-		return booleanValue;
+	public Boolean getBooleanValue() {
+		return booleanValue == null ? null : booleanValue == 1;
 	}
 
-	public void setBooleanValue(Integer booleanValue) {
-		this.booleanValue = booleanValue;
+	public void setBooleanValue(Boolean booleanValue) {
+		this.booleanValue = booleanValue == null ? null : (booleanValue ? 1 : 0);
 	}
 
 	public Date getDateValue() {


### PR DESCRIPTION
Orika's mapper could not map Boolean to Integer when mapping objects in
the REST facades (e.g. outputting UserDto entities that had embedded
boolean properties).

This does not break the public REST API: boolean types are still output
as integers in the response JSON.